### PR TITLE
Cache datasets that are reused during computations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,12 @@
             <artifactId>hbase-server</artifactId>
             <version>${maprdb.version}</version>
         </dependency>
-   
+
+        <dependency>
+            <groupId>com.databricks</groupId>
+            <artifactId>spark-csv_2.10</artifactId>
+            <version>1.5.0</version>
+        </dependency>
         
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/readme.txt
+++ b/readme.txt
@@ -24,7 +24,7 @@ Copy the data file using scp to here:
 
 To Run the Spark k-means program: 
 
-spark-submit --class com.sparkml.uber.ClusterUber --master local[2] --packages com.databricks:spark-csv_2.10:1.5.0  spark-kmeans-1.0.jar  
+spark-submit --class com.sparkml.uber.ClusterUber --master local[2] --packages com.databricks:spark-csv_2.10:1.5.0 spark-kmeans-1.0.jar
 
 you can also run the code in  ClusterUber.scala in the spark shell 
 

--- a/src/main/scala/com/sparkml/uber/ClusterUber.scala
+++ b/src/main/scala/com/sparkml/uber/ClusterUber.scala
@@ -38,13 +38,15 @@ object ClusterUber {
     val assembler = new VectorAssembler().setInputCols(featureCols).setOutputCol("features")
     val df2 = assembler.transform(df)
     val Array(trainingData, testData) = df2.randomSplit(Array(0.7, 0.3), 5043)
+    trainingData.cache()
+    testData.cache()
     // increase the iterations if running on a cluster (this runs on a 1 node sandbox)
     val kmeans = new KMeans().setK(8).setFeaturesCol("features").setMaxIter(1)
     val model = kmeans.fit(trainingData)
     println("Final Centers: ")
     model.clusterCenters.foreach(println)
 
-    val categories = model.transform(testData)
+    val categories = model.transform(testData).cache()
     
     categories.show
     categories.registerTempTable("uber")


### PR DESCRIPTION
Without caching, Spark recomputes a dataset on each action. Caching is especially important for the `trainingData` dataset, because it is accessed on each K-Means iteration.